### PR TITLE
Fix logic app workflow parameter definitions

### DIFF
--- a/infra/logic_app_definitions.tf
+++ b/infra/logic_app_definitions.tf
@@ -25,11 +25,7 @@ locals {
 
   # Function to process parameters.json files and replace placeholders
   processed_parameters = {
-    entry = {
-      "$connections" = {
-        value = local.storage_connection_params
-      }
-    }
+    entry = {}
 
     design_gen = {
       "$connections" = {

--- a/logic-apps/content-gen/workflow.json
+++ b/logic-apps/content-gen/workflow.json
@@ -1,7 +1,20 @@
 {
   "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {},
+  "parameters": {
+    "$connections": {
+      "type": "Object"
+    },
+    "ai_foundry_endpoint": {
+      "type": "String"
+    },
+    "gpt4_deployment_name": {
+      "type": "String"
+    },
+    "managed_identity_client_id": {
+      "type": "String"
+    }
+  },
   "triggers": {
     "When_a_new_message_is_received_in_a_queue": {
       "type": "ApiConnection",

--- a/logic-apps/design-gen/workflow.json
+++ b/logic-apps/design-gen/workflow.json
@@ -1,7 +1,20 @@
 {
   "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {},
+  "parameters": {
+    "$connections": {
+      "type": "Object"
+    },
+    "ai_foundry_endpoint": {
+      "type": "String"
+    },
+    "gpt4_deployment_name": {
+      "type": "String"
+    },
+    "managed_identity_client_id": {
+      "type": "String"
+    }
+  },
   "triggers": {
     "When_a_new_message_is_received_in_a_queue": {
       "type": "ApiConnection",

--- a/logic-apps/review/workflow.json
+++ b/logic-apps/review/workflow.json
@@ -1,7 +1,20 @@
 {
   "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {},
+  "parameters": {
+    "$connections": {
+      "type": "Object"
+    },
+    "ai_foundry_endpoint": {
+      "type": "String"
+    },
+    "gpt4_deployment_name": {
+      "type": "String"
+    },
+    "managed_identity_client_id": {
+      "type": "String"
+    }
+  },
   "triggers": {
     "When_a_new_message_is_received_in_a_queue": {
       "type": "ApiConnection",


### PR DESCRIPTION
## Summary
- ensure entry workflow deploys with no extra params
- declare Logic App parameters in workflow definitions

## Testing
- `bash validate.sh` *(fails: Missing workflow & script perms)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae47cb9883338ff7a104de535ec7